### PR TITLE
Fix UI pages and search

### DIFF
--- a/Data/Services/BookService.cs
+++ b/Data/Services/BookService.cs
@@ -30,12 +30,12 @@ public class BookService : BaseService<Book>
             .AsNoTracking();
         if (!string.IsNullOrWhiteSpace(q))
         {
-            q = q.Trim();
+            q = q.Trim().ToLower();
             query = query.Where(b =>
-                b.Title.Contains(q) ||
-                (b.Description != null && b.Description.Contains(q)) ||
-                b.Authors.Any(a => a.Author!.Name.Contains(q)) ||
-                (b.Publisher != null && b.Publisher.Name.Contains(q))
+                b.Title.ToLower().Contains(q) ||
+                (b.Description != null && b.Description.ToLower().Contains(q)) ||
+                b.Authors.Any(a => a.Author!.Name.ToLower().Contains(q)) ||
+                (b.Publisher != null && b.Publisher.Name.ToLower().Contains(q))
             );
         }
         return await query.ToListAsync();

--- a/Program.cs
+++ b/Program.cs
@@ -32,12 +32,12 @@ internal static class Program
         builder.Services.AddScoped<PublisherService>();
         builder.Services.AddScoped<LanguageCodeService>();
         builder.Services.AddScoped<LocationService>();
-        builder.Services.AddScoped<InventoryPage>();
+        builder.Services.AddTransient<InventoryPage>();
 
         builder.Services.AddScoped<MainForm>();
-        builder.Services.AddScoped<DebtsPage>();
-        builder.Services.AddScoped<ReadersPage>();
-        builder.Services.AddScoped<BookDetailForm>();
+        builder.Services.AddTransient<DebtsPage>();
+        builder.Services.AddTransient<ReadersPage>();
+        builder.Services.AddTransient<BookDetailForm>();
         return builder.Build();
     }
 

--- a/UI/Forms/BookDetailsForm.cs
+++ b/UI/Forms/BookDetailsForm.cs
@@ -56,11 +56,21 @@ public sealed class BookDetailForm : Form
 
         int y = 0;
         details.Controls.Add(Make(details, _book.Title, 20, FontStyle.Bold, ref y, Color.White));
-        var authorName = _book.Authors?.FirstOrDefault()?.Author?.Name ?? "";
-        details.Controls.Add(Make(details, $"Автор: {authorName}", 12, 0, ref y));
-        details.Controls.Add(Make(details, $"ISBN: {_book.ISBN}", 12, 0, ref y));
+        string authors = string.Join(", ", _book.Authors.Select(a => a.Author!.Name));
+        if (!string.IsNullOrEmpty(authors))
+            details.Controls.Add(Make(details, $"Автор(ы): {authors}", 12, 0, ref y));
+        string genres = string.Join(", ", _book.Genres.Select(g => g.Genre!.Name));
+        if (!string.IsNullOrEmpty(genres))
+            details.Controls.Add(Make(details, $"Жанр: {genres}", 12, 0, ref y));
+        if (_book.Language is not null)
+            details.Controls.Add(Make(details, $"Язык: {_book.Language.Code}", 12, 0, ref y));
+        if (_book.Publisher is not null)
+            details.Controls.Add(Make(details, $"Издатель: {_book.Publisher.Name}", 12, 0, ref y));
         if (_book.PublishYear != null)
-            details.Controls.Add(Make(details, $"Год: {_book.PublishYear}",12,0,ref y));
+            details.Controls.Add(Make(details, $"Год издания: {_book.PublishYear}",12,0,ref y));
+        if (_book.Pages != null)
+            details.Controls.Add(Make(details, $"Страниц: {_book.Pages}",12,0,ref y));
+        details.Controls.Add(Make(details, $"ISBN: {_book.ISBN}", 12, 0, ref y));
         details.Controls.Add(Make(details, $"Описание:",12,FontStyle.Bold, ref y));
         var descBox = new TextBox
         {
@@ -120,7 +130,35 @@ internal sealed class TransactionsDialog : Form
         BackColor = Color.FromArgb(24,24,28);
         ForeColor = Color.Gainsboro;
 
-        var grid = new DataGridView { Dock = DockStyle.Fill, ReadOnly = true };
+        var grid = new DataGridView
+        {
+            Dock = DockStyle.Fill,
+            ReadOnly = true,
+            AutoGenerateColumns = true,
+            BackgroundColor = Color.FromArgb(40, 40, 46),
+            ForeColor = Color.Gainsboro,
+            BorderStyle = BorderStyle.None,
+            CellBorderStyle = DataGridViewCellBorderStyle.SingleHorizontal
+        };
+        var style = new DataGridViewCellStyle
+        {
+            BackColor = Color.FromArgb(40, 40, 46),
+            ForeColor = Color.Gainsboro,
+            SelectionBackColor = Color.FromArgb(98, 0, 238),
+            SelectionForeColor = Color.White
+        };
+        grid.DefaultCellStyle = style;
+        grid.RowsDefaultCellStyle = style;
+        grid.AlternatingRowsDefaultCellStyle = new DataGridViewCellStyle(style)
+        {
+            BackColor = Color.FromArgb(32, 32, 38)
+        };
+        grid.ColumnHeadersDefaultCellStyle = new DataGridViewCellStyle
+        {
+            BackColor = Color.FromArgb(55, 55, 60),
+            ForeColor = Color.White
+        };
+        grid.EnableHeadersVisualStyles = false;
         Controls.Add(grid);
 
         Shown += async (_,__) =>

--- a/UI/Forms/DebtsPage.cs
+++ b/UI/Forms/DebtsPage.cs
@@ -31,6 +31,7 @@ public sealed class DebtsPage : TablePageBase
         Text = "Долги";
         MinimumSize = new Size(1000, 700);
         StartPosition = FormStartPosition.CenterParent;
+        WindowState = FormWindowState.Maximized;
 
         var header = new Label
         {

--- a/UI/Forms/InventoryPage.cs
+++ b/UI/Forms/InventoryPage.cs
@@ -43,6 +43,7 @@ namespace LibraryApp.UI.Forms
             Text          = "Инвентарь";
             MinimumSize   = new Size(1100, 700);
             StartPosition = FormStartPosition.CenterParent;
+            WindowState   = FormWindowState.Maximized;
 
             // --- Секция локаций ---
             var lblLoc = new Label

--- a/UI/Forms/MainForm.cs
+++ b/UI/Forms/MainForm.cs
@@ -486,32 +486,39 @@ namespace LibraryApp.UI.Forms
             var textPanel = new Panel
             {
                 Dock = DockStyle.Fill,
-                Padding = new Padding(10, 8, 6, 0)
+                Padding = new Padding(10, 8, 6, 0),
+                Tag = book
             };
-            textPanel.Controls.Add(new Label
+            var lblYear = new Label
             {
                 Text = book.PublishYear.ToString(),
                 Dock = DockStyle.Top,
                 Height = 18,
                 Font = new Font("Segoe UI", 9),
-                ForeColor = Color.Silver
-            });
-            textPanel.Controls.Add(new Label
+                ForeColor = Color.Silver,
+                Tag = book
+            };
+            textPanel.Controls.Add(lblYear);
+            var lblAuthor = new Label
             {
                 Text = author,
                 Dock = DockStyle.Top,
                 Height = 22,
                 Font = new Font("Segoe UI", 10),
-                ForeColor = Color.Gainsboro
-            });
-            textPanel.Controls.Add(new Label
+                ForeColor = Color.Gainsboro,
+                Tag = book
+            };
+            textPanel.Controls.Add(lblAuthor);
+            var lblTitle = new Label
             {
                 Text = title,
                 Dock = DockStyle.Top,
                 Height = 32,
                 Font = new Font("Segoe UI", 13, FontStyle.Bold),
-                ForeColor = Color.White
-            });
+                ForeColor = Color.White,
+                Tag = book
+            };
+            textPanel.Controls.Add(lblTitle);
 
             // Клик по любой части карточки открывает детали книги
             card.Click += OnCardClick;

--- a/UI/Forms/ReadersPage.cs
+++ b/UI/Forms/ReadersPage.cs
@@ -26,6 +26,7 @@ public sealed class ReadersPage : TablePageBase
         Text = "Читатели";
         MinimumSize = new Size(900, 650);
         StartPosition = FormStartPosition.CenterParent;
+        WindowState = FormWindowState.Maximized;
 
         var header = new Label
         {


### PR DESCRIPTION
## Summary
- open inventory, debts, and readers pages maximized
- recreate forms each time via transient services
- make book search case-insensitive
- allow clicking anywhere on a book card to open details
- expand book details fields and use dark theme for transaction history

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e2461db8832693ad2a3aab2159e5