### PR TITLE
Improve search and UI layout

### DIFF
--- a/Data/Services/BookService.cs
+++ b/Data/Services/BookService.cs
@@ -21,23 +21,19 @@ public class BookService : BaseService<Book>
 
     public async Task<IReadOnlyList<Book>> FullTextAsync(string q)
     {
-        await using var db = await Factory.CreateDbContextAsync();
-        IQueryable<Book> query = db.Books
-            .Include(b => b.Publisher)
-            .Include(b => b.Language)
-            .Include(b => b.Authors).ThenInclude(ab => ab.Author)
-            .Include(b => b.Genres).ThenInclude(gb => gb.Genre)
-            .AsNoTracking();
-        if (!string.IsNullOrWhiteSpace(q))
-        {
-            q = q.Trim().ToLower();
-            query = query.Where(b =>
-                b.Title.ToLower().Contains(q) ||
-                (b.Description != null && b.Description.ToLower().Contains(q)) ||
-                b.Authors.Any(a => a.Author!.Name.ToLower().Contains(q)) ||
-                (b.Publisher != null && b.Publisher.Name.ToLower().Contains(q))
-            );
-        }
-        return await query.ToListAsync();
+        var all = await GetAllDetailedAsync();
+
+        if (string.IsNullOrWhiteSpace(q))
+            return all;
+
+        return all.Where(b =>
+                b.Title.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                (!string.IsNullOrWhiteSpace(b.Description) &&
+                     b.Description.Contains(q, StringComparison.OrdinalIgnoreCase)) ||
+                b.Authors.Any(a => a.Author!.Name.Contains(q, StringComparison.OrdinalIgnoreCase)) ||
+                (b.Publisher != null &&
+                     b.Publisher.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+            )
+            .ToList();
     }
 }

--- a/UI/Forms/BookDetailsForm.cs
+++ b/UI/Forms/BookDetailsForm.cs
@@ -104,11 +104,15 @@ public sealed class BookDetailForm : Form
         {
             Text = t,
             AutoSize = true,
+            MaximumSize = new Size(parent.Width - 10, 0),
             Left = 0,
             Top = y,
             Font = new Font("Segoe UI", sz, fs),
             ForeColor = c ?? Color.Gainsboro
         };
+        // Предварительно вычисляем высоту с учётом переноса
+        var preferred = lbl.GetPreferredSize(new Size(parent.Width - 10, 0));
+        lbl.Size = preferred;
         y += lbl.Height + 6;
         return lbl;
     }

--- a/UI/Forms/DebtsPage.cs
+++ b/UI/Forms/DebtsPage.cs
@@ -91,7 +91,22 @@ public sealed class DebtsPage : TablePageBase
             if (await Delete()) await LoadAsync();
         });
         Controls.AddRange(new Control[] { btnAdd, btnEdit, btnDel });
-        Shown += async (_, __) => await LoadAsync();
+        Shown += async (_, __) =>
+        {
+            AdjustLayout();
+            await LoadAsync();
+        };
+        Resize += (_, __) => AdjustLayout();
+
+        void AdjustLayout()
+        {
+            int margin = 20;
+            btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+            btnEdit.Top = btnAdd.Top;
+            btnDel.Top = btnAdd.Top;
+
+            _grid.Height = btnAdd.Top - _grid.Top - 10;
+        }
     }
 
     private async Task LoadAsync()

--- a/UI/Forms/InventoryPage.cs
+++ b/UI/Forms/InventoryPage.cs
@@ -156,9 +156,24 @@ namespace LibraryApp.UI.Forms
 
             Shown += async (_, __) =>
             {
+                AdjustLayout();
                 await LoadLocationsAsync();
                 await LoadTransactionsAsync();
             };
+            Resize += (_, __) => AdjustLayout();
+
+            void AdjustLayout()
+            {
+                int margin = 20;
+                btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+                btnEdit.Top = btnAdd.Top;
+                btnDel.Top = btnAdd.Top;
+
+                btnAddTr.Top = ClientSize.Height - btnAddTr.Height - margin;
+
+                _gridLoc.Height = btnAdd.Top - _gridLoc.Top - 10;
+                _gridTrans.Height = btnAddTr.Top - _gridTrans.Top - 10;
+            }
         }
 
         // --- Сортировка ---

--- a/UI/Forms/MainForm.cs
+++ b/UI/Forms/MainForm.cs
@@ -83,7 +83,6 @@ namespace LibraryApp.UI.Forms
 
             // По показу формы загружаем карточки
             Shown += async (_, __) => await LoadCardsAsync();
-            Activated += async (_, __) => await LoadCardsAsync(_search!.Text);
         }
 
         /// <summary>

--- a/UI/Forms/ReaderTicketsPage.cs
+++ b/UI/Forms/ReaderTicketsPage.cs
@@ -67,10 +67,25 @@ namespace LibraryApp.UI.Forms
 
             // 5) Кнопки «Добавить» и «Удалить» ниже таблицы
             var (btnAdd, btnEdit, btnDel) = CreateActionButtons();
-            Controls.AddRange([btnAdd, btnDel]);
+            Controls.AddRange([btnAdd, btnEdit, btnDel]);
 
             // 6) При показе формы — загружаем данные
-            Shown += async (_, __) => await RefreshGridAsync();
+            Shown += async (_, __) =>
+            {
+                AdjustLayout();
+                await RefreshGridAsync();
+            };
+            Resize += (_, __) => AdjustLayout();
+
+            void AdjustLayout()
+            {
+                int margin = 20;
+                btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+                btnEdit.Top = btnAdd.Top;
+                btnDel.Top = btnAdd.Top;
+
+                _grid.Height = btnAdd.Top - _grid.Top - 10;
+            }
         }
 
         /// <summary>

--- a/UI/Forms/ReadersPage.cs
+++ b/UI/Forms/ReadersPage.cs
@@ -86,7 +86,22 @@ public sealed class ReadersPage : TablePageBase
             if (await DeleteAsync()) await LoadAsync();
         });
         Controls.AddRange(new Control[] { btnAdd, btnEdit, btnDel });
-        Shown += async (_, __) => await LoadAsync();
+        Shown += async (_, __) =>
+        {
+            AdjustLayout();
+            await LoadAsync();
+        };
+        Resize += (_, __) => AdjustLayout();
+
+        void AdjustLayout()
+        {
+            int margin = 20;
+            btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+            btnEdit.Top = btnAdd.Top;
+            btnDel.Top = btnAdd.Top;
+
+            _grid.Height = btnAdd.Top - _grid.Top - 10;
+        }
     }
 
     private async Task LoadAsync()


### PR DESCRIPTION
## Summary
- improve full-text search to ignore case and match substrings
- drop auto refresh on focus from MainForm
- fix book detail labels so long text wraps correctly
- reposition action buttons on table pages when resizing
- show edit button on reader tickets page

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684600c639a48326bf5c29d4a808eb6c