### PR TITLE
Add publishers page and improve forms

### DIFF
--- a/Data/Services/BookService.cs
+++ b/Data/Services/BookService.cs
@@ -21,23 +21,19 @@ public class BookService : BaseService<Book>
 
     public async Task<IReadOnlyList<Book>> FullTextAsync(string q)
     {
-        await using var db = await Factory.CreateDbContextAsync();
-        IQueryable<Book> query = db.Books
-            .Include(b => b.Publisher)
-            .Include(b => b.Language)
-            .Include(b => b.Authors).ThenInclude(ab => ab.Author)
-            .Include(b => b.Genres).ThenInclude(gb => gb.Genre)
-            .AsNoTracking();
-        if (!string.IsNullOrWhiteSpace(q))
-        {
-            q = q.Trim().ToLower();
-            query = query.Where(b =>
-                b.Title.ToLower().Contains(q) ||
-                (b.Description != null && b.Description.ToLower().Contains(q)) ||
-                b.Authors.Any(a => a.Author!.Name.ToLower().Contains(q)) ||
-                (b.Publisher != null && b.Publisher.Name.ToLower().Contains(q))
-            );
-        }
-        return await query.ToListAsync();
+        var all = await GetAllDetailedAsync();
+
+        if (string.IsNullOrWhiteSpace(q))
+            return all;
+
+        return all.Where(b =>
+                b.Title.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                (!string.IsNullOrWhiteSpace(b.Description) &&
+                     b.Description.Contains(q, StringComparison.OrdinalIgnoreCase)) ||
+                b.Authors.Any(a => a.Author!.Name.Contains(q, StringComparison.OrdinalIgnoreCase)) ||
+                (b.Publisher != null &&
+                     b.Publisher.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+            )
+            .ToList();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,7 @@ internal static class Program
         builder.Services.AddScoped<LanguageCodeService>();
         builder.Services.AddScoped<LocationService>();
         builder.Services.AddTransient<InventoryPage>();
+        builder.Services.AddTransient<PublishersPage>();
 
         builder.Services.AddScoped<MainForm>();
         builder.Services.AddTransient<DebtsPage>();

--- a/UI/Forms/BookDetailsForm.cs
+++ b/UI/Forms/BookDetailsForm.cs
@@ -96,6 +96,50 @@ public sealed class BookDetailForm : Form
         };
         btnHistory.Click += (_,__) => ShowTransactions();
         Controls.Add(btnHistory);
+
+        var btnEdit = new Button
+        {
+            Text = "Обновить",
+            Left = btnHistory.Right + 10,
+            Top = btnHistory.Top,
+            Width = 110,
+            Height = 36,
+            BackColor = Color.FromArgb(98,0,238),
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat
+        };
+        btnEdit.Click += async (_,__) =>
+        {
+            using var dlg = new BookEditDialog(_books, _book);
+            if (dlg.ShowDialog(this) == DialogResult.OK)
+            {
+                var fresh = await _books.GetByIdAsync(_book.BookId);
+                if (fresh is not null) _book = fresh;
+                Controls.Clear();
+                BuildUI();
+            }
+        };
+        Controls.Add(btnEdit);
+
+        var btnDelete = new Button
+        {
+            Text = "Удалить",
+            Left = btnEdit.Right + 10,
+            Top = btnHistory.Top,
+            Width = 110,
+            Height = 36,
+            BackColor = Color.FromArgb(98,0,238),
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat
+        };
+        btnDelete.Click += async (_,__) =>
+        {
+            if (MessageBox.Show("Удалить книгу?", "Подтверждение", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                return;
+            if (await _books.DeleteAsync(_book.BookId))
+                Close();
+        };
+        Controls.Add(btnDelete);
     }
 
     private static Label Make(Control parent,string t,int sz,FontStyle fs,ref int y,Color? c=null)
@@ -104,11 +148,15 @@ public sealed class BookDetailForm : Form
         {
             Text = t,
             AutoSize = true,
+            MaximumSize = new Size(parent.Width - 10, 0),
             Left = 0,
             Top = y,
             Font = new Font("Segoe UI", sz, fs),
             ForeColor = c ?? Color.Gainsboro
         };
+        // Предварительно вычисляем высоту с учётом переноса
+        var preferred = lbl.GetPreferredSize(new Size(parent.Width - 10, 0));
+        lbl.Size = preferred;
         y += lbl.Height + 6;
         return lbl;
     }
@@ -166,5 +214,87 @@ internal sealed class TransactionsDialog : Form
             var list = await service.GetForBookAsync(book.BookId);
             grid.DataSource = list.Select(t => new { t.InventoryTransactionId, t.Date, t.Amount, Location = t.Location!.LocationName }).ToList();
         };
+    }
+}
+
+internal sealed class BookEditDialog : Form
+{
+    private readonly BookService _books;
+    private readonly Book _book;
+    private readonly TextBox tTitle = new();
+    private readonly TextBox tIsbn = new();
+    private readonly NumericUpDown numYear = new() { Minimum = 0, Maximum = DateTime.Now.Year };
+    private readonly NumericUpDown numPages = new() { Minimum = 0, Maximum = 10000 };
+    private readonly TextBox tDesc = new() { Multiline = true, Height = 80 };
+
+    public BookEditDialog(BookService books, Book book)
+    {
+        _books = books;
+        _book = book;
+
+        Text = "Редактирование";
+        Size = new Size(500, 400);
+        StartPosition = FormStartPosition.CenterParent;
+        BackColor = Color.FromArgb(40, 40, 46);
+        ForeColor = Color.Gainsboro;
+        Font = new Font("Segoe UI", 10);
+
+        int y = 20;
+        Controls.Add(new Label { Text = "Название", AutoSize = true, Left = 20, Top = y });
+        tTitle.At(150, y - 3, 320); Controls.Add(tTitle);
+
+        Controls.Add(new Label { Text = "ISBN", AutoSize = true, Left = 20, Top = y += 35 });
+        tIsbn.At(150, y - 3, 200); Controls.Add(tIsbn);
+
+        Controls.Add(new Label { Text = "Год", AutoSize = true, Left = 20, Top = y += 35 });
+        numYear.At(150, y - 3); Controls.Add(numYear);
+
+        Controls.Add(new Label { Text = "Страниц", AutoSize = true, Left = 20, Top = y += 35 });
+        numPages.At(150, y - 3); Controls.Add(numPages);
+
+        Controls.Add(new Label { Text = "Описание", AutoSize = true, Left = 20, Top = y += 35 });
+        tDesc.At(150, y - 3, 320); Controls.Add(tDesc);
+
+        var ok = new Button
+        {
+            Text = "Сохранить",
+            DialogResult = DialogResult.OK,
+            Left = Width / 2 - 70,
+            Top = 310,
+            Width = 140,
+            Height = 45,
+            BackColor = Color.FromArgb(98, 0, 238),
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat
+        };
+        Controls.Add(ok);
+
+        Load += (_, __) =>
+        {
+            tTitle.Text = _book.Title;
+            tIsbn.Text = _book.ISBN;
+            if (_book.PublishYear is int yv) numYear.Value = yv;
+            if (_book.Pages is int p) numPages.Value = p;
+            tDesc.Text = _book.Description ?? string.Empty;
+        };
+
+        ok.Click += async (_, __) => await SaveAsync();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(tTitle.Text) || string.IsNullOrWhiteSpace(tIsbn.Text))
+        {
+            MessageBox.Show("Название и ISBN обязательны");
+            DialogResult = DialogResult.None;
+            return;
+        }
+
+        _book.Title = tTitle.Text;
+        _book.ISBN = tIsbn.Text;
+        _book.PublishYear = (int)numYear.Value;
+        _book.Pages = (int)numPages.Value;
+        _book.Description = tDesc.Text;
+        await _books.UpdateAsync(_book);
     }
 }

--- a/UI/Forms/DebtsPage.cs
+++ b/UI/Forms/DebtsPage.cs
@@ -91,7 +91,22 @@ public sealed class DebtsPage : TablePageBase
             if (await Delete()) await LoadAsync();
         });
         Controls.AddRange(new Control[] { btnAdd, btnEdit, btnDel });
-        Shown += async (_, __) => await LoadAsync();
+        Shown += async (_, __) =>
+        {
+            AdjustLayout();
+            await LoadAsync();
+        };
+        Resize += (_, __) => AdjustLayout();
+
+        void AdjustLayout()
+        {
+            int margin = 20;
+            btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+            btnEdit.Top = btnAdd.Top;
+            btnDel.Top = btnAdd.Top;
+
+            _grid.Height = btnAdd.Top - _grid.Top - 10;
+        }
     }
 
     private async Task LoadAsync()

--- a/UI/Forms/InventoryPage.cs
+++ b/UI/Forms/InventoryPage.cs
@@ -26,15 +26,24 @@ namespace LibraryApp.UI.Forms
         private readonly LocationService                 _locations;
         private readonly InventoryTransactionService      _transactions;
         private readonly IDbContextFactory<LibraryContext> _db;
+        private readonly PublisherService                _publishers;
+        private readonly GenreService                   _genres;
+        private readonly LanguageCodeService            _languages;
 
         public InventoryPage(
             LocationService locations,
             InventoryTransactionService transactions,
-            IDbContextFactory<LibraryContext> db)
+            IDbContextFactory<LibraryContext> db,
+            PublisherService publishers,
+            GenreService genres,
+            LanguageCodeService languages)
         {
             _locations   = locations;
             _transactions = transactions;
             _db           = db;
+            _publishers   = publishers;
+            _genres       = genres;
+            _languages    = languages;
             BuildUI();
         }
 
@@ -78,6 +87,7 @@ namespace LibraryApp.UI.Forms
 
             _gridLoc = CreateGrid(hintLoc.Bottom + 5, _bsLocations);
             _gridLoc.Width = 520;
+            _gridLoc.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
             _gridLoc.ColumnHeaderMouseClick += async (s, e)
                 => await LoadLocationsAsync(_gridLoc.Columns[e.ColumnIndex].DataPropertyName);
             Controls.Add(_gridLoc);
@@ -142,13 +152,14 @@ namespace LibraryApp.UI.Forms
             _gridTrans = CreateGrid(hintTr.Bottom + 5, _bsTrans);
             _gridTrans.Left = offsetLeft;
             _gridTrans.Width = 520;
+            _gridTrans.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
             _gridTrans.ColumnHeaderMouseClick += async (s, e)
                 => await LoadTransactionsAsync(_gridTrans.Columns[e.ColumnIndex].DataPropertyName);
             Controls.Add(_gridTrans);
 
             var btnAddTr = MakeButton("Создать", _gridTrans.Left, _gridTrans.Bottom + 10, async (_, __) =>
             {
-                using var page = new TransactionAddPage(_transactions, _locations, _db);
+                using var page = new TransactionAddPage(_transactions, _locations, _db, _publishers, _genres, _languages);
                 if (page.ShowDialog(this) == DialogResult.OK)
                     await LoadTransactionsAsync();
             });
@@ -156,9 +167,24 @@ namespace LibraryApp.UI.Forms
 
             Shown += async (_, __) =>
             {
+                AdjustLayout();
                 await LoadLocationsAsync();
                 await LoadTransactionsAsync();
             };
+            Resize += (_, __) => AdjustLayout();
+
+            void AdjustLayout()
+            {
+                int margin = 20;
+                btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+                btnEdit.Top = btnAdd.Top;
+                btnDel.Top = btnAdd.Top;
+
+                btnAddTr.Top = ClientSize.Height - btnAddTr.Height - margin;
+
+                _gridLoc.Height = btnAdd.Top - _gridLoc.Top - 10;
+                _gridTrans.Height = btnAddTr.Top - _gridTrans.Top - 10;
+            }
         }
 
         // --- Сортировка ---
@@ -355,6 +381,9 @@ namespace LibraryApp.UI.Forms
         private readonly InventoryTransactionService _transactions;
         private readonly LocationService             _locations;
         private readonly IDbContextFactory<LibraryContext> _db;
+        private readonly PublisherService            _publishers;
+        private readonly GenreService               _genres;
+        private readonly LanguageCodeService        _languages;
 
         private readonly ComboBox      cbTo     = new() { DropDownStyle = ComboBoxStyle.DropDownList };
         private readonly ComboBox      cbFrom   = new() { DropDownStyle = ComboBoxStyle.DropDownList };
@@ -366,29 +395,35 @@ namespace LibraryApp.UI.Forms
         private readonly TextBox       tIsbn   = new();
         private readonly TextBox       tTitle  = new();
         private readonly NumericUpDown tYear   = new() { Minimum = 0, Maximum = DateTime.Now.Year, Value = DateTime.Now.Year };
-        private readonly TextBox       tPublisher = new();
-        private readonly TextBox       tLanguage  = new();
+        private readonly ComboBox      cbPublisher = new() { DropDownStyle = ComboBoxStyle.DropDownList };
+        private readonly ComboBox      cbLanguage  = new() { DropDownStyle = ComboBoxStyle.DropDownList };
         private readonly TextBox       tDescription = new() { Multiline = true, Height = 60, ScrollBars = ScrollBars.Vertical };
         private readonly NumericUpDown tPages   = new() { Minimum = 1, Maximum = 10000 };
-        private readonly TextBox       tGenre   = new();
+        private readonly ComboBox      cbGenre   = new() { DropDownStyle = ComboBoxStyle.DropDownList };
         private readonly TextBox       tCover   = new() { ReadOnly = true, BackColor = SystemColors.Window };
         private readonly Button        btnBrowse = new() { Text = "Файл…", Height = 30 };
 
         public TransactionAddPage(
             InventoryTransactionService transactions,
             LocationService locations,
-            IDbContextFactory<LibraryContext> db)
+            IDbContextFactory<LibraryContext> db,
+            PublisherService publishers,
+            GenreService genres,
+            LanguageCodeService languages)
         {
             _transactions = transactions;
             _locations    = locations;
             _db           = db;
+            _publishers   = publishers;
+            _genres       = genres;
+            _languages    = languages;
             BuildUI();
         }
 
         private void BuildUI()
         {
             Text          = "Новая транзакция";
-            Size          = new Size(1000, 700);
+            Size          = new Size(1100, 760);
             StartPosition = FormStartPosition.CenterParent;
             BackColor     = Color.FromArgb(24, 24, 28);
             ForeColor     = Color.Gainsboro;
@@ -437,13 +472,13 @@ namespace LibraryApp.UI.Forms
                 tIsbn.At(120, y2-3, 320),
 
                 new Label{Text="Издатель", AutoSize=true, Left=0, Top=y2+=35},
-                tPublisher.At(120, y2-3, 320),
+                cbPublisher.At(120, y2-3, 320),
 
                 new Label{Text="Год", AutoSize=true, Left=0, Top=y2+=35},
                 tYear.At(120, y2-3, 120),
 
                 new Label{Text="Язык", AutoSize=true, Left=0, Top=y2+=35},
-                tLanguage.At(120, y2-3, 200),
+                cbLanguage.At(120, y2-3, 200),
 
                 new Label{Text="Название", AutoSize=true, Left=0, Top=y2+=35},
                 tTitle.At(120, y2-3, 320),
@@ -459,7 +494,7 @@ namespace LibraryApp.UI.Forms
                 btnBrowse.At(330, y2-4, 80),
 
                 new Label{Text="Жанр", AutoSize=true, Left=0, Top=y2+=35},
-                tGenre.At(120, y2-3, 320)
+                cbGenre.At(120, y2-3, 320)
             });
             Controls.Add(bookPanel);
 
@@ -468,7 +503,11 @@ namespace LibraryApp.UI.Forms
 
             btnBrowse.Click += ChooseCover;
 
-            Shown += async (_, __) => await LoadLocationsAsync();
+            Shown += async (_, __) =>
+            {
+                await LoadLocationsAsync();
+                await LoadLookupDataAsync();
+            };
 
             var btnOk = new Button
             {
@@ -493,6 +532,18 @@ namespace LibraryApp.UI.Forms
             cbTo.DisplayMember    = nameof(ModelLocation.LocationName);
             cbFrom.DataSource     = list.ToList();
             cbFrom.DisplayMember  = nameof(ModelLocation.LocationName);
+        }
+
+        private async Task LoadLookupDataAsync()
+        {
+            cbPublisher.DataSource = (await _publishers.GetAllAsync()).ToList();
+            cbPublisher.DisplayMember = nameof(Publisher.Name);
+
+            cbLanguage.DataSource = (await _languages.GetAllAsync()).ToList();
+            cbLanguage.DisplayMember = nameof(LanguageCode.Code);
+
+            cbGenre.DataSource = (await _genres.GetAllAsync()).ToList();
+            cbGenre.DisplayMember = nameof(Genre.Name);
         }
 
         private void ChooseCover(object? sender, EventArgs e)
@@ -526,8 +577,12 @@ namespace LibraryApp.UI.Forms
                     PublishYear = (int)tYear.Value,
                     Description = tDescription.Text,
                     Pages       = (int)tPages.Value,
-                    CoverUrl    = "no_cover.png"
+                    CoverUrl    = "no_cover.png",
+                    PublisherId = cbPublisher.SelectedItem is Publisher p ? p.PublisherId : null,
+                    LangId      = cbLanguage.SelectedItem is LanguageCode l ? l.LangId : 0,
                 };
+                if (cbGenre.SelectedItem is Genre g)
+                    book.Genres.Add(new GenreBook { GenreId = g.GenreId });
                 await using var db = await _db.CreateDbContextAsync();
                 db.Books.Add(book);
                 await db.SaveChangesAsync();

--- a/UI/Forms/MainForm.cs
+++ b/UI/Forms/MainForm.cs
@@ -83,7 +83,6 @@ namespace LibraryApp.UI.Forms
 
             // По показу формы загружаем карточки
             Shown += async (_, __) => await LoadCardsAsync();
-            Activated += async (_, __) => await LoadCardsAsync(_search!.Text);
         }
 
         /// <summary>
@@ -101,7 +100,7 @@ namespace LibraryApp.UI.Forms
             };
 
             Color accent = Color.FromArgb(98, 0, 238);
-            string[] navPages = { "Инвентарь", "Долги", "Читатели" };
+            string[] navPages = { "Инвентарь", "Долги", "Читатели", "Издатели" };
 
             foreach (string navPage in navPages)
             {
@@ -128,6 +127,10 @@ namespace LibraryApp.UI.Forms
                             break;
                         case "Читатели":
                             using (var f = _provider.GetRequiredService<ReadersPage>())
+                                f.ShowDialog(this);
+                            break;
+                        case "Издатели":
+                            using (var f = _provider.GetRequiredService<PublishersPage>())
                                 f.ShowDialog(this);
                             break;
                     }

--- a/UI/Forms/PublishersPage.cs
+++ b/UI/Forms/PublishersPage.cs
@@ -1,0 +1,205 @@
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using LibraryApp.Data.Models;
+using LibraryApp.Data.Services;
+using LibraryApp.UI.Helpers;
+
+namespace LibraryApp.UI.Forms;
+
+public sealed class PublishersPage : TablePageBase
+{
+    private readonly BindingSource _bs = new();
+    private DataGridView _grid = null!;
+    private TextBox _search = null!;
+    private string _sortColumn = nameof(Publisher.PublisherId);
+    private SortOrder _sortOrder = SortOrder.Ascending;
+    private readonly PublisherService _publishers;
+
+    public PublishersPage(PublisherService publishers)
+    {
+        _publishers = publishers;
+        BuildUI();
+    }
+
+    private void BuildUI()
+    {
+        Text = "Издатели";
+        MinimumSize = new Size(700, 500);
+        StartPosition = FormStartPosition.CenterParent;
+        WindowState = FormWindowState.Maximized;
+
+        var header = new Label
+        {
+            Text = Text,
+            Font = new Font("Segoe UI", 22, FontStyle.Bold),
+            ForeColor = Color.White,
+            AutoSize = true,
+            Left = 20,
+            Top = 20
+        };
+        Controls.Add(header);
+
+        _search = new TextBox
+        {
+            PlaceholderText = "  Поиск по имени…",
+            Left = 20,
+            Top = header.Bottom + 10,
+            Width = 640,
+            Height = 30
+        };
+        _search.TextChanged += async (_, __) => await LoadAsync();
+        Controls.Add(_search);
+
+        var hint = new Label
+        {
+            Text = "Сортировка при нажатии на названия полей таблицы",
+            AutoSize = true,
+            Left = 20,
+            Top = _search.Bottom + 5
+        };
+        Controls.Add(hint);
+
+        _grid = CreateGrid(hint.Bottom + 5, _bs);
+        _grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+        _grid.ColumnHeaderMouseClick += async (s, e) =>
+        {
+            var col = _grid.Columns[e.ColumnIndex].DataPropertyName;
+            if (_sortColumn == col)
+                _sortOrder = _sortOrder == SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
+            else
+            {
+                _sortColumn = col;
+                _sortOrder = SortOrder.Ascending;
+            }
+            await LoadAsync();
+        };
+        Controls.Add(_grid);
+
+        var (btnAdd, btnEdit, btnDel) = CreateActionButtons();
+        Controls.AddRange(new Control[] { btnAdd, btnEdit, btnDel });
+
+        Shown += async (_, __) =>
+        {
+            AdjustLayout();
+            await LoadAsync();
+        };
+        Resize += (_, __) => AdjustLayout();
+
+        void AdjustLayout()
+        {
+            int margin = 20;
+            btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+            btnEdit.Top = btnAdd.Top;
+            btnDel.Top = btnAdd.Top;
+            _grid.Height = btnAdd.Top - _grid.Top - 10;
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        var list = await _publishers.GetAllAsync();
+        string filter = _search.Text.Trim().ToLower();
+        if (!string.IsNullOrEmpty(filter))
+            list = list.Where(p => p.Name.ToLower().Contains(filter)).ToList();
+
+        list = _sortColumn switch
+        {
+            nameof(Publisher.Name) => _sortOrder == SortOrder.Ascending ? list.OrderBy(p => p.Name).ToList() : list.OrderByDescending(p => p.Name).ToList(),
+            _ => _sortOrder == SortOrder.Ascending ? list.OrderBy(p => p.PublisherId).ToList() : list.OrderByDescending(p => p.PublisherId).ToList()
+        };
+
+        _bs.DataSource = list.Select(p => new { p.PublisherId, Имя = p.Name }).ToList();
+    }
+
+    private (Button, Button, Button) CreateActionButtons()
+    {
+        var btnAdd = MakeButton("Создать", _grid.Left, _grid.Bottom + 15, async (_, __) =>
+        {
+            using var dlg = new PublisherDialog(_publishers);
+            if (dlg.ShowDialog(this) == DialogResult.OK)
+                await LoadAsync();
+        });
+        var btnEdit = MakeButton("Обновить", btnAdd.Right + 10, btnAdd.Top, async (_, __) => await EditAsync());
+        var btnDel = MakeButton("Удалить", btnEdit.Right + 10, btnAdd.Top, async (_, __) =>
+        {
+            if (await DeleteAsync()) await LoadAsync();
+        });
+        return (btnAdd, btnEdit, btnDel);
+    }
+
+    private async Task EditAsync()
+    {
+        if (_grid.CurrentRow?.Cells["PublisherId"].Value is not long id) return;
+        var entity = await _publishers.GetByIdAsync(id);
+        if (entity is null) return;
+        using var dlg = new PublisherDialog(_publishers, entity);
+        if (dlg.ShowDialog(this) == DialogResult.OK)
+            await LoadAsync();
+    }
+
+    private async Task<bool> DeleteAsync()
+    {
+        if (_grid.CurrentRow?.Cells["PublisherId"].Value is not long id) return false;
+        if (MessageBox.Show("Удалить издателя?", "Подтверждение", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+            return false;
+        return await _publishers.DeleteAsync(id);
+    }
+}
+
+internal sealed class PublisherDialog : Form
+{
+    private readonly TextBox tName = new();
+    private readonly PublisherService _service;
+    private readonly Publisher? _orig;
+
+    public PublisherDialog(PublisherService service, Publisher? existing = null)
+    {
+        _service = service;
+        _orig = existing;
+        Text = existing is null ? "Новый издатель" : "Редактирование";
+        Size = new Size(400, 200);
+        StartPosition = FormStartPosition.CenterParent;
+        BackColor = Color.FromArgb(40, 40, 46);
+        ForeColor = Color.Gainsboro;
+        Font = new Font("Segoe UI", 10);
+
+        int y = 20;
+        Controls.Add(new Label { Text = "Имя", AutoSize = true, Left = 20, Top = y });
+        tName.At(150, y - 3, 200); Controls.Add(tName);
+
+        var ok = new Button
+        {
+            Text = "Сохранить",
+            DialogResult = DialogResult.OK,
+            Left = Width / 2 - 70,
+            Top = 100,
+            Width = 140,
+            Height = 45,
+            BackColor = Color.FromArgb(98, 0, 238),
+            ForeColor = Color.White,
+            FlatStyle = FlatStyle.Flat
+        };
+        Controls.Add(ok);
+
+        if (existing is not null)
+            tName.Text = existing.Name;
+
+        ok.Click += async (_, __) =>
+        {
+            if (string.IsNullOrWhiteSpace(tName.Text))
+            {
+                MessageBox.Show("Имя обязательно");
+                DialogResult = DialogResult.None;
+                return;
+            }
+            if (_orig is null)
+                await _service.AddAsync(new Publisher { Name = tName.Text });
+            else
+            {
+                _orig.Name = tName.Text;
+                await _service.UpdateAsync(_orig);
+            }
+        };
+    }
+}

--- a/UI/Forms/ReaderTicketsPage.cs
+++ b/UI/Forms/ReaderTicketsPage.cs
@@ -67,10 +67,25 @@ namespace LibraryApp.UI.Forms
 
             // 5) Кнопки «Добавить» и «Удалить» ниже таблицы
             var (btnAdd, btnEdit, btnDel) = CreateActionButtons();
-            Controls.AddRange([btnAdd, btnDel]);
+            Controls.AddRange([btnAdd, btnEdit, btnDel]);
 
             // 6) При показе формы — загружаем данные
-            Shown += async (_, __) => await RefreshGridAsync();
+            Shown += async (_, __) =>
+            {
+                AdjustLayout();
+                await RefreshGridAsync();
+            };
+            Resize += (_, __) => AdjustLayout();
+
+            void AdjustLayout()
+            {
+                int margin = 20;
+                btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+                btnEdit.Top = btnAdd.Top;
+                btnDel.Top = btnAdd.Top;
+
+                _grid.Height = btnAdd.Top - _grid.Top - 10;
+            }
         }
 
         /// <summary>

--- a/UI/Forms/ReadersPage.cs
+++ b/UI/Forms/ReadersPage.cs
@@ -60,6 +60,7 @@ public sealed class ReadersPage : TablePageBase
         Controls.Add(hint);
 
         _grid = CreateGrid(hint.Bottom + 5, _bs);
+        _grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
         _grid.ColumnHeaderMouseClick += async (s, e) =>
         {
             var col = _grid.Columns[e.ColumnIndex].DataPropertyName;
@@ -86,7 +87,22 @@ public sealed class ReadersPage : TablePageBase
             if (await DeleteAsync()) await LoadAsync();
         });
         Controls.AddRange(new Control[] { btnAdd, btnEdit, btnDel });
-        Shown += async (_, __) => await LoadAsync();
+        Shown += async (_, __) =>
+        {
+            AdjustLayout();
+            await LoadAsync();
+        };
+        Resize += (_, __) => AdjustLayout();
+
+        void AdjustLayout()
+        {
+            int margin = 20;
+            btnAdd.Top = ClientSize.Height - btnAdd.Height - margin;
+            btnEdit.Top = btnAdd.Top;
+            btnDel.Top = btnAdd.Top;
+            _grid.Height = btnAdd.Top - _grid.Top - 10;
+            _grid.Width = ClientSize.Width - 40;
+        }
     }
 
     private async Task LoadAsync()
@@ -161,15 +177,15 @@ internal sealed class ReaderDialog : Form
         Controls.AddRange(new Control[]
         {
             new Label { Text = "ФИО", AutoSize = true, Left = 20, Top = y },
-            tName.At(150, y - 3, 240),
+            tName.At(180, y - 3, 220),
             new Label { Text = "E-mail", AutoSize = true, Left = 20, Top = y += 35 },
-            tEmail.At(150, y - 3, 240),
+            tEmail.At(180, y - 3, 220),
             new Label { Text = "Телефон", AutoSize = true, Left = 20, Top = y += 35 },
-            tPhone.At(150, y - 3, 240),
+            tPhone.At(180, y - 3, 220),
             new Label { Text = "Дата регистрации", AutoSize = true, Left = 20, Top = y += 35 },
-            dpReg.At(150, y - 3),
+            dpReg.At(180, y - 3),
             new Label { Text = "Окончание", AutoSize = true, Left = 20, Top = y += 35 },
-            dpEnd.At(150, y - 3)
+            dpEnd.At(180, y - 3)
         });
 
         var ok = new Button


### PR DESCRIPTION
## Summary
- add update and delete buttons to book details and new editing dialog
- create PublishersPage with CRUD and integrate into navigation
- improve transaction dialog: dropdowns for publisher, genre and language
- adjust ReadersPage layout and auto-size columns
- widen transaction dialog window and load lookup data

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684600c639a48326bf5c29d4a808eb6c